### PR TITLE
Autostart and Hold between reboots

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,5 +1,5 @@
 # Summary
-A simple application for the pinephone to launch applications using gestures
+A simple application for the pinephone to launch applications using gestures. Note that the autostart only works on mobian.
 
 # Compiling
 ```
@@ -15,4 +15,18 @@ on phone:
 pine_gestures [--shake_cmd <cmd>] [--twist_cmd <cmd>];
 	--shake_cmd		path to cmd to be triggered by shake gesture or 'none' to disable. default: /usr/bin/toggleflash
     --twist_cmd		path to cmd to be triggered by twist gesture or 'none' to disable. default: /usr/bin/pinhole
+```
+
+# Autostart
+Copy the service file to the systemd folder, ensure that you are in the pine_gestures directory
+```
+sudo cp  gestures.service /etc/systemd/system/gestures.service
+```
+Then simple start the service with
+```
+sudo systemctl start gestures.service
+```
+And make sure it is active with
+```
+sudo systemctl status gestures.service
 ```

--- a/README.MD
+++ b/README.MD
@@ -20,7 +20,7 @@ pine_gestures [--shake_cmd <cmd>] [--twist_cmd <cmd>];
 # Autostart
 Copy the service file to the systemd folder, ensure that you are in the pine_gestures directory
 ```
-sudo cp  gestures.service /etc/systemd/system/gestures.service
+sudo cp gestures.service /etc/systemd/system/gestures.service
 ```
 Then simple start the service with
 ```

--- a/gestures.service
+++ b/gestures.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Pine Gestures that will turn torch on when device is shaken
+After=default.target
+
+[Service]
+ExecStart=/home/mobian/pine_gestures/startup_gestures.sh
+
+[Install]
+WantedBy=default.target

--- a/startup_gestures.sh
+++ b/startup_gestures.sh
@@ -1,0 +1,4 @@
+#!bin/sh
+
+# script to run on startup to have pine_gestures on every boot
+pine_gestures


### PR DESCRIPTION
The following two files will ensure that once the systemd service has been started that the gestures works between reboots. It also means you don't have to have a terminal open running the command (or trying to disown it)